### PR TITLE
fixed a bug with missing an argument

### DIFF
--- a/lib/config_system.py
+++ b/lib/config_system.py
@@ -39,4 +39,4 @@ if __name__ == '__main__':
     try:
         get_config()
     except:
-        save_folder()
+        save_folder(config_class())


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Contents

* added one instance to the argument

## Reasons

* save_folder function requires one argument