### PR TITLE
changed license batch to represent Decentra-Network`s license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Decentra Network | [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/) [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/onuratakan/Decentra-Network/blob/master/LICENSE)
+# Decentra Network | [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/) [![GitHub license](https://img.shields.io/github/license/Decentra-Network/Decentra-Network)](https://github.com/onuratakan/Decentra-Network/blob/master/LICENSE)
 
 # Introducing
 This is an open source decentralized application network. In this network, you can develop and publish decentralized applications.


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Contents

* changed license batch to represent Decentra-Network`s license

## Reasons

* The Decentra-Network\`s license is currently `MPL-2.0`, but it was listed as `MIT`
* It is not recommended to use license badges of other repositories because If the repository is deleted, the license badge may not be displayed.