### PR TITLE
Fixes for candidate blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ settings.json
 connected_node.json
 unl_nodes.json
 temp_block.decentra_network
+temp_candidate_blocks.decentra_network
 loading_block.decentra_network
 blockchain.decentra_network
 wallet_list.json

--- a/config.py
+++ b/config.py
@@ -9,6 +9,9 @@ CONNECTED_NODE_PATH = 'db/connected_node.json'
 UNL_NODES_PATH = 'db/unl_nodes.json'
 
 TEMP_BLOCK_PATH = 'db/temp_block.decentra_network'
+
+TEMP_CANDIDATE_BLOCKS_PATH = 'db/temp_candidate_blocks.decentra_network'
+
 LOADING_BLOCK_PATH = 'db/loading_block.decentra_network'
 
 BLOCKCHAIN_PATH = 'db/blockchain.decentra_network'

--- a/node/myownp2pn.py
+++ b/node/myownp2pn.py
@@ -145,9 +145,8 @@ class mynode (Node):
 
     def get_candidate_block(self,data,node):
 
-      from blockchain.block.block_main import get_block
+      
       dprint("Getting the candidate block")
-      system = get_block()
       from node.unl import node_is_unl
       if node_is_unl(node.id):
             dprint("is unl")
@@ -177,16 +176,17 @@ class mynode (Node):
                     temp_tx.append(Transaction.load_json(element))
 
                 data["transaction"] = temp_tx
-                
-                system.candidate_blocks.append(data)
-                system.save_block()
+                from blockchain.block.block_main import get_candidate_block
+                candidate_class = get_candidate_block()
+                candidate_class.candidate_blocks.append(data)
+                candidate_class.save_candidate_blocks()
 
 
     def get_candidate_block_hash(self,data,node):
 
-      from blockchain.block.block_main import get_block
+
       dprint("Getting the candidate block hash")
-      system = get_block()
+
       from node.unl import node_is_unl
       if node_is_unl(node.id):
             dprint("is unl")
@@ -196,9 +196,10 @@ class mynode (Node):
                 dprint("ecdsa true")
                 data["sender"] = node.id
 
-                
-                system.candidate_block_hashes.append(data)
-                system.save_block()
+                from blockchain.block.block_main import get_candidate_block
+                candidate_class = get_candidate_block()                
+                candidate_class.candidate_block_hashes.append(data)
+                candidate_class.save_candidate_blocks()
 
 
 


### PR DESCRIPTION
# Reasons
- Candidate blocks can be discarded when they are in the block class and the changes are recorded in parallel.


# Solution
- A new candidate block class has been created and candidate blocks are moved there