### PR TITLE
prevent that index_out_of_range is thrown when there is no wallet

### DIFF
--- a/src/wallet/wallet.py
+++ b/src/wallet/wallet.py
@@ -1028,6 +1028,11 @@ def Wallet_Import(account,mode,password = None):
     """
 
     temp_saved_wallet = get_saved_wallet()
+
+    number_of_wallet = len(temp_saved_wallet)
+    if not number_of_wallet:
+        return None
+
     if isinstance(account,int):
         if not -1 == account:
             account = list(temp_saved_wallet)[account]


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

If there is no wallet, get_saved_wallet returns an empty dictionary. The result of converting this to a list type is an empty list.
Of course, index_out_of_range will occur even if you access by specifying 0 for index.

```
if not -1 == account:
            account = list(temp_saved_wallet)[account]
        else:
            account = list(temp_saved_wallet)[the_settings()["wallet"]]
```

In this part I confirmed that the error occurred.