### PR TITLE
github: Changed Github-Actions label to GitHub

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -100,7 +100,7 @@ changelog:
 
     - title: GitHub
       labels:
-        - Github-Actions
+        - GitHub
 
     - title: Google
       labels:


### PR DESCRIPTION
Closes #593 