### PR TITLE
github: Changed "APPS" label to "Apps"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,7 @@ labels:
     - '\bwallet\b'
   'Accounts':
     - '\baccounts\b'
-  'APPS':
+  'Apps':
     - '\bapps\b'
   'Auto-Builders':
     - '\bauto_builders\b'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -34,9 +34,9 @@ changelog:
       labels:
         - Accounts
 
-    - title: APPS
+    - title: Apps
       labels:
-        - APPS
+        - Apps
 
     - title: Auto-Builders
       labels:


### PR DESCRIPTION
## Why ? 

Closes #914

## Checking
- [x] No personal details (pass and etc.)
