### PR TITLE
api: Added `/transactions/all` API for getting all transactions

### DIFF
--- a/decentra_network/api/main.py
+++ b/decentra_network/api/main.py
@@ -323,6 +323,12 @@ def transaction_received_not_validated_page():
     return jsonify(
         GetMyTransaction(sended=False, validated=False, turn_json=True))
 
+@app.route("/transactions/all", methods=["GET"])
+def transaction_all_page():
+    logger.info(
+        f"{request.remote_addr} {request.method} {request.url} {request.data}")
+    return jsonify(
+        GetMyTransaction(turn_json=True))
 
 @app.route("/status", methods=["GET"])
 def status_page():

--- a/tests/unit_tests/test_api.py
+++ b/tests/unit_tests/test_api.py
@@ -90,6 +90,7 @@ class Test_API(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.maxDiff = None        
         CleanUp_tests()
         decentra_network.api.main.account_list = GetAccounts(temp_path)
 
@@ -821,5 +822,49 @@ class Test_API(unittest.TestCase):
 
         SaveMyTransaction(backup)
 
+
+    def test_transaction_all_page(self):
+        backup = GetMyTransaction()
+        SaveMyTransaction({})
+
+        new_transaction = Transaction(1, "gf", "", "", "", 1, 1, 1)
+        SavetoMyTransaction(new_transaction, sended=True, validated=False)
+
+        new_transaction = Transaction(1, "gff", "", "", "", 1, 1, 1)
+        SavetoMyTransaction(new_transaction, sended=False, validated=True)
+
+        new_transaction = Transaction(1, "c", "", "", {"data": "dadata"}, 1, 1,
+                                      1)
+        SavetoMyTransaction(new_transaction, sended=False, validated=False)
+
+        response = urllib.request.urlopen(
+            "http://localhost:7777/transactions/all")
+
+        result = response.read()
+        
+        
+        result = json.loads(result)
+
+        self.assertEqual(
+            result["0"]["transaction"]["data"],
+            "",
+        )
+
+        self.assertEqual(
+            result["1"]["transaction"]["data"],
+            "",
+        )
+
+        self.assertEqual(
+            result["2"]["transaction"]["data"],
+            "{'data': 'dadata'}",
+        )
+
+        self.assertEqual(
+            str(result),
+            """{'0': {'sended': True, 'transaction': {'amount': 1.0, 'data': '', 'fromUser': '', 'sequance_number': 1, 'signature': 'gf', 'toUser': '', 'transaction_fee': 1.0, 'transaction_time': 1}, 'validated': False}, '1': {'sended': False, 'transaction': {'amount': 1.0, 'data': '', 'fromUser': '', 'sequance_number': 1, 'signature': 'gff', 'toUser': '', 'transaction_fee': 1.0, 'transaction_time': 1}, 'validated': True}, '2': {'sended': False, 'transaction': {'amount': 1.0, 'data': "{'data': 'dadata'}", 'fromUser': '', 'sequance_number': 1, 'signature': 'c', 'toUser': '', 'transaction_fee': 1.0, 'transaction_time': 1}, 'validated': False}}""",
+        )
+
+        SaveMyTransaction(backup)
 
 unittest.main(exit=False)


### PR DESCRIPTION
## Why ? 

Closes #1152

## Checking
- [x] No personal details (pass and etc.)
