### PR TITLE
tests: Increased consensus_trigger expected time to 2

### DIFF
--- a/tests/unit_tests/test_consensus.py
+++ b/tests/unit_tests/test_consensus.py
@@ -2854,7 +2854,7 @@ class Test_Consensus(unittest.TestCase):
             custom_TEMP_BLOCKSHASH_PART_PATH=custom_TEMP_BLOCKSHASH_PART_PATH,
         )
         self.assertTrue(result[1])
-        self.assertLess(result[0], 1)
+        self.assertLess(result[0], 2)
 
         result_2 = GetBlockstoBlockchainDB(
             sequance_number=0,


### PR DESCRIPTION
## Why ? 

I am sending this pr because some checks are complated as unsuccess without any possible problem.

## Checking
- [x] No personal details (pass and etc.)
