### PR TITLE
node: Added an exit the message reception loop when a destination node is closed

### DIFF
--- a/decentra_network/node/client/client.py
+++ b/decentra_network/node/client/client.py
@@ -39,6 +39,11 @@ class client(Thread):
                 logger.debug(
                     f"NODE:{self.server.host}:{self.server.port} SOCK:{self.host}:{self.port} Received data"
                 )
+
+                # check if a destination node is closed
+                if not data:
+                    break
+
                 data = data.decode("utf-8")
                 with contextlib.suppress(json.decoder.JSONDecodeError):
                     data = json.loads(data)

--- a/decentra_network/node/client/client.py
+++ b/decentra_network/node/client/client.py
@@ -40,7 +40,6 @@ class client(Thread):
                     f"NODE:{self.server.host}:{self.server.port} SOCK:{self.host}:{self.port} Received data"
                 )
 
-                # check if a destination node is closed
                 if not data:
                     break
 


### PR DESCRIPTION
Long time no see.
I am also honored to have the opportunity to submit a pull request for this project.

Closes #1316 

## Why ? 
If the connection destination has closed the socket, `recv(length)` method will return an empty bytes type.
In the repro below, you can see the result of the server receiving an empty bytes type `b""` due to the client closing the socket.

### server

```python
import socket
server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
server.bind(("127.0.0.1", 1024))
server.listen(1)
client, addr = server.accept()
print(client.recv(1024))
```

### client

```python
import socket
client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
client.connect(("127.0.0.1", 1024))
client.close()
```

I don't know the details of the data alieren196 received, so I can't be sure, but I think this is probably the cause of #1316
The empty data `b""` received is successfully decoded as an empty string in utf-8.

## Checking
- [x] No personal details (pass and etc.)
