### PR TITLE
blockchain: Changed share transactions from users for sorting

### DIFF
--- a/decentra_network/blockchain/block/change_transaction_fee.py
+++ b/decentra_network/blockchain/block/change_transaction_fee.py
@@ -26,7 +26,7 @@ def ChangeTransactionFee(
                             custom_pending_transaction_len)
     validating_list_len = 0
     for tx in block.validating_list:
-        if tx.fromUser != "DN":
+        if tx.signature != "DN":
             validating_list_len += 1
     total_len = validating_list_len + pending_transactions
     logger.debug(f"total_len: {total_len}")

--- a/decentra_network/blockchain/block/shares.py
+++ b/decentra_network/blockchain/block/shares.py
@@ -38,7 +38,7 @@ def shares(block: Block, custom_shares=None, custom_fee_address=None) -> list:
                     Transaction(
                         0,
                         "DN",
-                        "DN",
+                        "DNB",
                         share[0],
                         "NP",
                         share[1],
@@ -54,7 +54,7 @@ def shares(block: Block, custom_shares=None, custom_fee_address=None) -> list:
             Transaction(
                 0,
                 "DN",
-                "DN",
+                "DNA",
                 the_fee_address,
                 "NP",
                 fee,


### PR DESCRIPTION
## Why ? 

Closes #1375

## Checking
- [x] No personal details (pass and etc.)
