### PR TITLE
blockchain: Changed transaction time with block.start_time for share transactions

### DIFF
--- a/decentra_network/blockchain/block/shares.py
+++ b/decentra_network/blockchain/block/shares.py
@@ -27,7 +27,7 @@ def shares(block: Block, custom_shares=None, custom_fee_address=None) -> list:
 
     tx_list = []
 
-    the_time = time.time()
+    the_time = block.start_time
     logger.debug(f"the_time: {the_time}")
 
     for share in the_shares:


### PR DESCRIPTION
## Why ? 

Closes #1378

## Checking
- [x] No personal details (pass and etc.)
