### PR TITLE
tests: Fix for test_blockchain_sync_empty_blocks_first_and_second_empty_is_not_equal

### DIFF
--- a/tests/unit_tests/test_blockchain.py
+++ b/tests/unit_tests/test_blockchain.py
@@ -1259,13 +1259,13 @@ class Test_Blockchain(unittest.TestCase):
             self):
 
         block = Block("onur")
-        block.sequence_number = 1
-        block.empty_block_number = 2
-        block.block_time = 0.5
+        block.sequence_number = 0
+        block.empty_block_number = 1
+        block.block_time = 3
         block.validated = False
 
         first_block = copy.copy(block)
-        time.sleep(2)
+        time.sleep(7.5)
         block.sync_empty_blocks()
         second_block = copy.copy(block)
 


### PR DESCRIPTION
## Why ? 

I am sending this pr because... (If you send for an issue please use "Closes #issuenumber" for here.)

## Checking
- [ ] No personal details (pass and etc.)
